### PR TITLE
IAA: fix audio path to AUM (closes #17)

### DIFF
--- a/PhaseRings.xcodeproj/xcshareddata/xcschemes/PhaseRings.xcscheme
+++ b/PhaseRings.xcodeproj/xcshareddata/xcschemes/PhaseRings.xcscheme
@@ -79,13 +79,6 @@
             ReferencedContainer = "container:PhaseRings.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <EnvironmentVariables>
-         <EnvironmentVariable
-            key = "OS_ACTIVITY_MODE"
-            value = "disable"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-      </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/PhaseRings/ViewController.m
+++ b/PhaseRings/ViewController.m
@@ -96,8 +96,11 @@
     [self.experimentNewSetupButton setHidden:YES];
     [self.compositionStepper setHidden:NO];
     [self updateUITextLabels];
-    [self startAudioEngine];
+    // Order matters for IAA: session must be configured with MixWithOthers
+    // before the audio unit is created, and the unit must be live before
+    // publication so hosts can connect to a real render callback.
     [self setupAudioSession];
+    [self startAudioEngine];
     [self publishAsNode];
     
     [PdBase setDelegate:self];
@@ -127,14 +130,16 @@
 
 #pragma mark - Audio Setup Methods.
 -(void) setupAudioSession {
-    // this is the currently known working combination of AVAudioSession Category and Options.
-    NSString *category = AVAudioSessionCategoryPlayback; // previously AVAudioSessionCategoryPlayAndRecord;
-    AVAudioSessionCategoryOptions options = AVAudioSessionCategoryOptionAllowBluetoothA2DP|AVAudioSessionCategoryOptionMixWithOthers|AVAudioSessionCategoryOptionDefaultToSpeaker;
+    // MixWithOthers is mandatory for Inter-App Audio hosting.
+    // DefaultToSpeaker is only valid with PlayAndRecord; including it with
+    // Playback caused setCategory to fail and silently drop MixWithOthers.
+    NSString *category = AVAudioSessionCategoryPlayback;
+    AVAudioSessionCategoryOptions options = AVAudioSessionCategoryOptionAllowBluetoothA2DP|AVAudioSessionCategoryOptionMixWithOthers;
     NSError *error = nil;
     if ( ![[AVAudioSession sharedInstance] setCategory:category withOptions:options error:&error] ) {
         NSLog(@"Couldn't set audio session category: %@", error);
     } else {
-        NSLog(@"Audio Session category set to PlayAndRecord.");
+        NSLog(@"Audio Session category set to Playback (MixWithOthers).");
     }
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(handleAudioSessionInterruption:)

--- a/PhaseRings/ViewController.m
+++ b/PhaseRings/ViewController.m
@@ -90,6 +90,13 @@ static void IAAConnectionChangedCallback(void *inRefCon,
                                          AudioUnitScope inScope,
                                          AudioUnitElement inElement);
 
+static OSStatus IAARenderNotifyCallback(void *inRefCon,
+                                        AudioUnitRenderActionFlags *ioActionFlags,
+                                        const AudioTimeStamp *inTimeStamp,
+                                        UInt32 inBusNumber,
+                                        UInt32 inNumberFrames,
+                                        AudioBufferList *ioData);
+
 @implementation ViewController
 #pragma mark - Setup
 - (PdAudioController *) audioController
@@ -178,6 +185,16 @@ static void IAAConnectionChangedCallback(void *inRefCon,
     if (listenErr != noErr) {
         NSLog(@"IAA: failed to install IsInterAppConnected listener (%d)", (int)listenErr);
     }
+
+    // Diagnostic: log render activity (throttled) to tell whether any host or
+    // the local speaker is actually pulling samples, and whether the resulting
+    // buffer has signal in it.
+    OSStatus rnErr = AudioUnitAddRenderNotify(unit,
+                                              IAARenderNotifyCallback,
+                                              (__bridge void *)self);
+    if (rnErr != noErr) {
+        NSLog(@"IAA: failed to install render-notify (%d)", (int)rnErr);
+    }
 }
 
 - (void) handleIAAConnectionChange {
@@ -213,6 +230,43 @@ static void IAAConnectionChangedCallback(void *inRefCon,
     dispatch_async(dispatch_get_main_queue(), ^{
         [vc handleIAAConnectionChange];
     });
+}
+
+static OSStatus IAARenderNotifyCallback(void *inRefCon,
+                                        AudioUnitRenderActionFlags *ioActionFlags,
+                                        const AudioTimeStamp *inTimeStamp,
+                                        UInt32 inBusNumber,
+                                        UInt32 inNumberFrames,
+                                        AudioBufferList *ioData) {
+    // Called on the audio thread. fprintf isn't strictly RT-safe but is
+    // acceptable for a throttled diagnostic; remove once IAA is resolved.
+    static UInt32 preCount = 0;
+    static UInt32 postCount = 0;
+    if (*ioActionFlags & kAudioUnitRenderAction_PreRender) {
+        if ((preCount++ % 200) == 0) {
+            fprintf(stderr,
+                    "IAA: render PRE  n=%u bus=%u frames=%u\n",
+                    (unsigned)preCount, (unsigned)inBusNumber, (unsigned)inNumberFrames);
+        }
+    } else if (*ioActionFlags & kAudioUnitRenderAction_PostRender) {
+        Float32 peak = 0.0f;
+        if (ioData && ioData->mNumberBuffers > 0 && ioData->mBuffers[0].mData) {
+            const Float32 *samples = (const Float32 *)ioData->mBuffers[0].mData;
+            UInt32 nFrames = ioData->mBuffers[0].mDataByteSize / sizeof(Float32);
+            for (UInt32 i = 0; i < nFrames; i++) {
+                Float32 a = fabsf(samples[i]);
+                if (a > peak) peak = a;
+            }
+        }
+        if ((postCount++ % 200) == 0) {
+            fprintf(stderr,
+                    "IAA: render POST n=%u bus=%u frames=%u peak=%.6f silence=%d\n",
+                    (unsigned)postCount, (unsigned)inBusNumber, (unsigned)inNumberFrames,
+                    peak,
+                    (*ioActionFlags & kAudioUnitRenderAction_OutputIsSilence) ? 1 : 0);
+        }
+    }
+    return noErr;
 }
 
 - (void) startAudioEngine {

--- a/PhaseRings/ViewController.m
+++ b/PhaseRings/ViewController.m
@@ -81,6 +81,12 @@
 @property (strong, nonatomic) NSDate* timeOfLastNewIdea;
 @end
 
+static void IAAConnectionChangedCallback(void *inRefCon,
+                                         AudioUnit inUnit,
+                                         AudioUnitPropertyID inID,
+                                         AudioUnitScope inScope,
+                                         AudioUnitElement inElement);
+
 @implementation ViewController
 #pragma mark - Setup
 - (PdAudioController *) audioController
@@ -154,16 +160,62 @@
         .componentSubType      = 'synt',
         .componentManufacturer = 'cmpc'
     };
+    AudioUnit unit = self.audioController.audioUnit.audioUnit;
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    OSStatus err = AudioOutputUnitPublish(&iaaDesc, CFSTR("PhaseRings"), 2,
-                                         self.audioController.audioUnit.audioUnit);
+    OSStatus err = AudioOutputUnitPublish(&iaaDesc, CFSTR("PhaseRings"), 2, unit);
 #pragma clang diagnostic pop
     if (err != noErr) {
         NSLog(@"IAA: AudioOutputUnitPublish failed (%d)", (int)err);
-    } else {
-        NSLog(@"IAA: Published as Remote Generator.");
+        return;
     }
+    NSLog(@"IAA: Published as Remote Generator.");
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    OSStatus listenErr = AudioUnitAddPropertyListener(unit,
+                                                      kAudioUnitProperty_IsInterAppConnected,
+                                                      IAAConnectionChangedCallback,
+                                                      (__bridge void *)self);
+#pragma clang diagnostic pop
+    if (listenErr != noErr) {
+        NSLog(@"IAA: failed to install IsInterAppConnected listener (%d)", (int)listenErr);
+    }
+}
+
+- (void) handleIAAConnectionChange {
+    AudioUnit unit = self.audioController.audioUnit.audioUnit;
+    UInt32 connected = 0;
+    UInt32 size = sizeof(connected);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    OSStatus err = AudioUnitGetProperty(unit,
+                                        kAudioUnitProperty_IsInterAppConnected,
+                                        kAudioUnitScope_Global,
+                                        0,
+                                        &connected,
+                                        &size);
+#pragma clang diagnostic pop
+    if (err != noErr) {
+        NSLog(@"IAA: failed to read IsInterAppConnected (%d)", (int)err);
+        return;
+    }
+    NSLog(@"IAA: connection state changed -> %@", connected ? @"CONNECTED" : @"DISCONNECTED");
+    if (connected && !self.audioController.isActive) {
+        NSLog(@"IAA: host connected but engine was inactive; activating.");
+        [self.audioController setActive:YES];
+    }
+}
+
+static void IAAConnectionChangedCallback(void *inRefCon,
+                                         AudioUnit inUnit,
+                                         AudioUnitPropertyID inID,
+                                         AudioUnitScope inScope,
+                                         AudioUnitElement inElement) {
+    ViewController *vc = (__bridge ViewController *)inRefCon;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [vc handleIAAConnectionChange];
+    });
 }
 
 - (void) startAudioEngine {

--- a/PhaseRings/ViewController.m
+++ b/PhaseRings/ViewController.m
@@ -90,13 +90,6 @@ static void IAAConnectionChangedCallback(void *inRefCon,
                                          AudioUnitScope inScope,
                                          AudioUnitElement inElement);
 
-static OSStatus IAARenderNotifyCallback(void *inRefCon,
-                                        AudioUnitRenderActionFlags *ioActionFlags,
-                                        const AudioTimeStamp *inTimeStamp,
-                                        UInt32 inBusNumber,
-                                        UInt32 inNumberFrames,
-                                        AudioBufferList *ioData);
-
 @implementation ViewController
 #pragma mark - Setup
 - (PdAudioController *) audioController
@@ -185,16 +178,6 @@ static OSStatus IAARenderNotifyCallback(void *inRefCon,
     if (listenErr != noErr) {
         NSLog(@"IAA: failed to install IsInterAppConnected listener (%d)", (int)listenErr);
     }
-
-    // Diagnostic: log render activity (throttled) to tell whether any host or
-    // the local speaker is actually pulling samples, and whether the resulting
-    // buffer has signal in it.
-    OSStatus rnErr = AudioUnitAddRenderNotify(unit,
-                                              IAARenderNotifyCallback,
-                                              (__bridge void *)self);
-    if (rnErr != noErr) {
-        NSLog(@"IAA: failed to install render-notify (%d)", (int)rnErr);
-    }
 }
 
 - (void) handleIAAConnectionChange {
@@ -259,43 +242,6 @@ static void IAAConnectionChangedCallback(void *inRefCon,
     dispatch_async(dispatch_get_main_queue(), ^{
         [vc handleIAAConnectionChange];
     });
-}
-
-static OSStatus IAARenderNotifyCallback(void *inRefCon,
-                                        AudioUnitRenderActionFlags *ioActionFlags,
-                                        const AudioTimeStamp *inTimeStamp,
-                                        UInt32 inBusNumber,
-                                        UInt32 inNumberFrames,
-                                        AudioBufferList *ioData) {
-    // Called on the audio thread. fprintf isn't strictly RT-safe but is
-    // acceptable for a throttled diagnostic; remove once IAA is resolved.
-    static UInt32 preCount = 0;
-    static UInt32 postCount = 0;
-    if (*ioActionFlags & kAudioUnitRenderAction_PreRender) {
-        if ((preCount++ % 200) == 0) {
-            fprintf(stderr,
-                    "IAA: render PRE  n=%u bus=%u frames=%u\n",
-                    (unsigned)preCount, (unsigned)inBusNumber, (unsigned)inNumberFrames);
-        }
-    } else if (*ioActionFlags & kAudioUnitRenderAction_PostRender) {
-        Float32 peak = 0.0f;
-        if (ioData && ioData->mNumberBuffers > 0 && ioData->mBuffers[0].mData) {
-            const Float32 *samples = (const Float32 *)ioData->mBuffers[0].mData;
-            UInt32 nFrames = ioData->mBuffers[0].mDataByteSize / sizeof(Float32);
-            for (UInt32 i = 0; i < nFrames; i++) {
-                Float32 a = fabsf(samples[i]);
-                if (a > peak) peak = a;
-            }
-        }
-        if ((postCount++ % 200) == 0) {
-            fprintf(stderr,
-                    "IAA: render POST n=%u bus=%u frames=%u peak=%.6f silence=%d\n",
-                    (unsigned)postCount, (unsigned)inBusNumber, (unsigned)inNumberFrames,
-                    peak,
-                    (*ioActionFlags & kAudioUnitRenderAction_OutputIsSilence) ? 1 : 0);
-        }
-    }
-    return noErr;
 }
 
 - (void) startAudioEngine {

--- a/PhaseRings/ViewController.m
+++ b/PhaseRings/ViewController.m
@@ -215,9 +215,38 @@ static OSStatus IAARenderNotifyCallback(void *inRefCon,
         return;
     }
     NSLog(@"IAA: connection state changed -> %@", connected ? @"CONNECTED" : @"DISCONNECTED");
-    if (connected && !self.audioController.isActive) {
-        NSLog(@"IAA: host connected but engine was inactive; activating.");
+    if (connected) {
+        // Even if isActive is YES, the underlying RemoteIO needs a full
+        // Stop/Uninit/Init/Start cycle for the IAA host bridge to start
+        // pulling. Apple's InterAppAudioSampler and briomusic's libpd-based
+        // interAppPDAudio both do this on every CONNECT. Without it the host
+        // never invokes our render callback.
+        NSLog(@"IAA: cycling audio engine to bind to host bridge.");
+        [self.audioController setActive:NO];
         [self.audioController setActive:YES];
+
+        // Query the host callbacks struct. Some hosts use this exchange as a
+        // "generator is ready" signal before they begin pulling.
+        HostCallbackInfo hostInfo;
+        UInt32 hostInfoSize = sizeof(hostInfo);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        OSStatus hcErr = AudioUnitGetProperty(unit,
+                                              kAudioUnitProperty_HostCallbacks,
+                                              kAudioUnitScope_Global,
+                                              0,
+                                              &hostInfo,
+                                              &hostInfoSize);
+#pragma clang diagnostic pop
+        if (hcErr == noErr) {
+            NSLog(@"IAA: host callbacks acquired (beat=%p musical=%p transport=%p transport2=%p)",
+                  hostInfo.beatAndTempoProc,
+                  hostInfo.musicalTimeLocationProc,
+                  hostInfo.transportStateProc,
+                  hostInfo.transportStateProc2);
+        } else {
+            NSLog(@"IAA: host callbacks unavailable (%d)", (int)hcErr);
+        }
     }
 }
 

--- a/PhaseRings/ViewController.m
+++ b/PhaseRings/ViewController.m
@@ -29,7 +29,10 @@
 #define NUMBER_COMPOSITIONS_AVAILABLE 5
 #define BASE_A 33
 #define BACKGROUND_SOUND_ALWAYS_ON YES
-#define SAMPLE_RATE 44100
+// Modern iPads run hardware at 48 kHz; asking for 44.1 forced libpd to log
+// "could not set session sample rate" and left the published IAA AU
+// advertising 44.1 while the host expected 48. Match the hardware.
+#define SAMPLE_RATE 48000
 #define SOUND_OUTPUT_CHANNELS 2
 //#define TICKS_PER_BUFFER 4
 
@@ -136,17 +139,11 @@ static void IAAConnectionChangedCallback(void *inRefCon,
 
 #pragma mark - Audio Setup Methods.
 -(void) setupAudioSession {
-    // MixWithOthers is mandatory for Inter-App Audio hosting.
-    // DefaultToSpeaker is only valid with PlayAndRecord; including it with
-    // Playback caused setCategory to fail and silently drop MixWithOthers.
-    NSString *category = AVAudioSessionCategoryPlayback;
-    AVAudioSessionCategoryOptions options = AVAudioSessionCategoryOptionAllowBluetoothA2DP|AVAudioSessionCategoryOptionMixWithOthers;
-    NSError *error = nil;
-    if ( ![[AVAudioSession sharedInstance] setCategory:category withOptions:options error:&error] ) {
-        NSLog(@"Couldn't set audio session category: %@", error);
-    } else {
-        NSLog(@"Audio Session category set to Playback (MixWithOthers).");
-    }
+    // PdAudioController configurePlayback... with mixingEnabled:YES already
+    // sets Playback + MixWithOthers (which IAA requires). Doing it again here
+    // races with whatever has already touched the session on device (PencilKit,
+    // UIScene) and fails with paramErr (-50), silently dropping MixWithOthers.
+    // Just register for interruptions; let libpd own the category.
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(handleAudioSessionInterruption:)
                                                  name:AVAudioSessionInterruptionNotification


### PR DESCRIPTION
Closes #17.

PhaseRings is now functional as an Inter-App Audio Remote Generator in AUM on iPad / iOS 26.3. Discovery, URL handoff, handshake, *and* the audio render path all work.

## Root cause

On `kAudioUnitProperty_IsInterAppConnected` firing CONNECTED, the underlying libpd RemoteIO needs a full Stop → Uninit → Init → Start cycle for the IAA host bridge to attach to it. Without that cycle the AU stays bound to its local-output state and the host never invokes our render callback — explaining the "handshake fires but AUM hears silence" symptom.

Apple's old `InterAppAudioSampler` and `briomusic/interAppPDAudio` (libpd-based) both do this cycle on every CONNECT. MobMuPlat sidesteps the issue by publishing via Audiobus 2.x's `ABSenderPort`, which performs the equivalent dance internally.

## Fixes in this branch

1. `f4af0c1` — reorder `viewDidLoad` so the audio session is configured before libpd creates its unit; drop the invalid `AVAudioSessionCategoryOptionDefaultToSpeaker` option that silently broke `MixWithOthers`.
2. `4934885` — install a `kAudioUnitProperty_IsInterAppConnected` listener so we can observe and react to host connect/disconnect.
3. `aa796e2` — remove `OS_ACTIVITY_MODE=disable` from the scheme so NSLog output reappears in Xcode's debug console (the env var was carried over from the template when the scheme was promoted to xcshareddata).
4. `dbb7cdf` — let libpd own the session configuration (it already sets Playback + MixWithOthers correctly via `configurePlayback…mixingEnabled:YES`); raise `SAMPLE_RATE` from 44100 → 48000 to match modern iPad hardware so the published AU and the system session agree.
5. `aa2512f` (+ revert `862dab3`) — temporary `AudioUnitAddRenderNotify` diagnostic that proved no one was pulling the AU after CONNECTED; reverted before landing.
6. `29caefa` — **the keystone**: on CONNECT, cycle `PdAudioController setActive:NO/YES` and fetch `kAudioUnitProperty_HostCallbacks`.

## Test plan

- [x] Builds cleanly for iPad Pro 11" simulator (iOS 26.5) with Debug + Release configs
- [x] On-device launch logs show the expected sequence: session set, AU running at 48 kHz, `IAA: Published as Remote Generator.`
- [x] AUM discovers PhaseRings as an IAA generator
- [x] URL handoff from AUM works
- [x] CONNECT notification fires and host callbacks come back non-null
- [x] Audio reaches AUM's channel strip with non-zero peak when rings are tapped
- [ ] Regression check: solo (non-IAA) audio still works on device (please confirm)
- [ ] DISCONNECT path: AUM → another generator → back to PhaseRings still produces audio (please confirm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)