### PR TITLE
Issue #26: remove Inter-App Audio

### DIFF
--- a/PhaseRings.entitlements
+++ b/PhaseRings.entitlements
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>inter-app-audio</key>
-	<true/>
-</dict>
+<dict/>
 </plist>

--- a/PhaseRings.xcodeproj/project.pbxproj
+++ b/PhaseRings.xcodeproj/project.pbxproj
@@ -1044,9 +1044,6 @@
 							com.apple.BackgroundModes = {
 								enabled = 1;
 							};
-							com.apple.InterAppAudio = {
-								enabled = 1;
-							};
 						};
 					};
 					5623DB80188CDB3800AA6C14 = {

--- a/PhaseRings/HeavyAudioEngine.h
+++ b/PhaseRings/HeavyAudioEngine.h
@@ -19,7 +19,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithSampleRate:(double)sampleRate channels:(int)channels;
 
-@property (nonatomic, readonly) AudioUnit audioUnit;
 @property (nonatomic, readonly) double sampleRate;
 @property (nonatomic, readonly) HeavySynth activeSynth;
 @property (nonatomic, getter=isActive) BOOL active;

--- a/PhaseRings/HeavyAudioEngine.mm
+++ b/PhaseRings/HeavyAudioEngine.mm
@@ -42,7 +42,6 @@
 
 #pragma mark - Pass-through properties
 
-- (AudioUnit)audioUnit { return _audioUnit; }
 - (double)sampleRate { return _core.sampleRate; }
 - (HeavySynth)activeSynth { return _core.activeSynth; }
 

--- a/PhaseRings/PhaseRings-Info.plist
+++ b/PhaseRings/PhaseRings-Info.plist
@@ -2,21 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>AudioComponents</key>
-	<array>
-		<dict>
-			<key>manufacturer</key>
-			<string>cmpc</string>
-			<key>name</key>
-			<string>PhaseRings</string>
-			<key>subtype</key>
-			<string>synt</string>
-			<key>type</key>
-			<string>aurg</string>
-			<key>version</key>
-			<integer>2</integer>
-		</dict>
-	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
@@ -49,8 +34,6 @@
 	</array>
 	<key>NSLocalNetworkUsageDescription</key>
 	<string>PhaseRings discovers other PhaseRings players and a gesture classifier on your local network for ensemble performance.</string>
-	<key>NSMicrophoneUsageDescription</key>
-	<string>PhaseRings uses the microphone for audio input when used with inter-app audio.</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>

--- a/PhaseRings/ViewController.m
+++ b/PhaseRings/ViewController.m
@@ -29,14 +29,12 @@
 #define NUMBER_COMPOSITIONS_AVAILABLE 5
 #define BACKGROUND_SOUND_ALWAYS_ON YES
 // Modern iPads run hardware at 48 kHz; asking for 44.1 forced libpd to log
-// "could not set session sample rate" and left the published IAA AU
-// advertising 44.1 while the host expected 48. Match the hardware.
+// "could not set session sample rate". Match the hardware.
 #define SAMPLE_RATE 48000
 #define SOUND_OUTPUT_CHANNELS 2
 //#define TICKS_PER_BUFFER 4
 
 #import "ViewController.h"
-#import <AudioToolbox/AudioToolbox.h>
 #import <AVFoundation/AVFoundation.h>
 #import "ScaleMaker.h"
 #import "SingingBowlSetup.h"
@@ -90,12 +88,6 @@
 @property (strong, nonatomic) id<PRSettingsStore> settingsStore;
 @end
 
-static void IAAConnectionChangedCallback(void *inRefCon,
-                                         AudioUnit inUnit,
-                                         AudioUnitPropertyID inID,
-                                         AudioUnitScope inScope,
-                                         AudioUnitElement inElement);
-
 @implementation ViewController
 #pragma mark - Setup
 - (id<PRSettingsStore>)settingsStore
@@ -122,12 +114,8 @@ static void IAAConnectionChangedCallback(void *inRefCon,
     [self.experimentNewSetupButton setHidden:YES];
     [self.compositionStepper setHidden:NO];
     [self updateUITextLabels];
-    // Order matters for IAA: session must be configured with MixWithOthers
-    // before the audio unit is created, and the unit must be live before
-    // publication so hosts can connect to a real render callback.
     [self setupAudioSession];
     [self startAudioEngine];
-    [self publishAsNode];
 
     self.midiManager = [[MetatoneMidiManager alloc] init];
     __weak typeof(self) weakSelf = self;
@@ -165,98 +153,6 @@ static void IAAConnectionChangedCallback(void *inRefCon,
                                              selector:@selector(handleAudioSessionInterruption:)
                                                  name:AVAudioSessionInterruptionNotification
                                                object:[AVAudioSession sharedInstance]];
-}
-
-- (void) publishAsNode {
-    // Register as an IAA Remote Generator so hosts like AUM can route our audio.
-    AudioComponentDescription iaaDesc = {
-        .componentType         = kAudioUnitType_RemoteGenerator,
-        .componentSubType      = 'synt',
-        .componentManufacturer = 'cmpc'
-    };
-    AudioUnit unit = self.audioEngine.audioUnit;
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    OSStatus err = AudioOutputUnitPublish(&iaaDesc, CFSTR("PhaseRings"), 2, unit);
-#pragma clang diagnostic pop
-    if (err != noErr) {
-        NSLog(@"IAA: AudioOutputUnitPublish failed (%d)", (int)err);
-        return;
-    }
-    NSLog(@"IAA: Published as Remote Generator.");
-
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    OSStatus listenErr = AudioUnitAddPropertyListener(unit,
-                                                      kAudioUnitProperty_IsInterAppConnected,
-                                                      IAAConnectionChangedCallback,
-                                                      (__bridge void *)self);
-#pragma clang diagnostic pop
-    if (listenErr != noErr) {
-        NSLog(@"IAA: failed to install IsInterAppConnected listener (%d)", (int)listenErr);
-    }
-}
-
-- (void) handleIAAConnectionChange {
-    AudioUnit unit = self.audioEngine.audioUnit;
-    UInt32 connected = 0;
-    UInt32 size = sizeof(connected);
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    OSStatus err = AudioUnitGetProperty(unit,
-                                        kAudioUnitProperty_IsInterAppConnected,
-                                        kAudioUnitScope_Global,
-                                        0,
-                                        &connected,
-                                        &size);
-#pragma clang diagnostic pop
-    if (err != noErr) {
-        NSLog(@"IAA: failed to read IsInterAppConnected (%d)", (int)err);
-        return;
-    }
-    NSLog(@"IAA: connection state changed -> %@", connected ? @"CONNECTED" : @"DISCONNECTED");
-    if (connected) {
-        // Even if the unit is running, the IAA host bridge often needs us to
-        // cycle Start/Stop on connect before it begins pulling. Apple's
-        // InterAppAudioSampler and briomusic's interAppPDAudio both do this.
-        NSLog(@"IAA: cycling audio engine to bind to host bridge.");
-        [self.audioEngine setActive:NO];
-        [self.audioEngine setActive:YES];
-
-        // Query the host callbacks struct. Some hosts use this exchange as a
-        // "generator is ready" signal before they begin pulling.
-        HostCallbackInfo hostInfo;
-        UInt32 hostInfoSize = sizeof(hostInfo);
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-        OSStatus hcErr = AudioUnitGetProperty(unit,
-                                              kAudioUnitProperty_HostCallbacks,
-                                              kAudioUnitScope_Global,
-                                              0,
-                                              &hostInfo,
-                                              &hostInfoSize);
-#pragma clang diagnostic pop
-        if (hcErr == noErr) {
-            NSLog(@"IAA: host callbacks acquired (beat=%p musical=%p transport=%p transport2=%p)",
-                  hostInfo.beatAndTempoProc,
-                  hostInfo.musicalTimeLocationProc,
-                  hostInfo.transportStateProc,
-                  hostInfo.transportStateProc2);
-        } else {
-            NSLog(@"IAA: host callbacks unavailable (%d)", (int)hcErr);
-        }
-    }
-}
-
-static void IAAConnectionChangedCallback(void *inRefCon,
-                                         AudioUnit inUnit,
-                                         AudioUnitPropertyID inID,
-                                         AudioUnitScope inScope,
-                                         AudioUnitElement inElement) {
-    ViewController *vc = (__bridge ViewController *)inRefCon;
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [vc handleIAAConnectionChange];
-    });
 }
 
 - (void) startAudioEngine {

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Three compositions of pitches are included in the app, but you can also create y
 - 3 built-in setups
 - Custom generative composition
 - 11 scales and modes
-- IAA support to stream audio to compatible apps
+- AUv3 instrument plugin to play PhaseRings inside compatible hosts
 - Core MIDI support for iOS MIDI Accessories
 
 ## performance

--- a/hvcc-migration-plan.md
+++ b/hvcc-migration-plan.md
@@ -193,9 +193,8 @@ After the Heavy integration is verified working:
   different audio engine semantics that need verification)
 - Audiobus already dropped (per `MEMORY.md`), so no Audiobus regression
   test needed
-- IAA: confirm still works under Heavy. The current `AudioOutputUnitPublish`
-  setup is libpd-agnostic (Core Audio level), so it should be unaffected
-  but verify
+- IAA: ~~confirm still works under Heavy~~ — **removed entirely (issue #26)**;
+  the AUv3 plugin replaces it as the inter-app audio route. No longer relevant.
 
 ### 6. Polyphony sanity-check
 


### PR DESCRIPTION
Closes #26.

Inter-App Audio is deprecated and now superseded by the AUv3 plugin, so this removes it entirely.

## Changes
- **`ViewController`**: delete `publishAsNode`, `handleIAAConnectionChange`, the `IsInterAppConnected` property listener + `IAAConnectionChangedCallback`, and the `<AudioToolbox/AudioToolbox.h>` import. `viewDidLoad` no longer publishes a Remote Generator (just sets up the session + starts the engine).
- **`HeavyAudioEngine`**: drop the now-dead `audioUnit` accessor — its only consumer was the IAA publish path.
- **`PhaseRings-Info.plist`**: remove the `AudioComponents` (`aurg` Remote Generator) registration and the stale `NSMicrophoneUsageDescription` (the app runs Playback-only, no audio input).
- **`PhaseRings.entitlements`**: remove `inter-app-audio`.
- **`project.pbxproj`**: drop the `com.apple.InterAppAudio` system capability.
- **README / hvcc plan**: replace IAA mentions with the AUv3 plugin.

The AUv3 extension's own `AudioComponents` (`aumu`) registration is untouched.

## Verification
- App + AUv3 appex **build clean** on the iPad Pro 11" (M5) simulator.

## Not in this PR (flagged for follow-up)
The public docs site still advertises IAA — `docs/index.html` (feature badge, body copy, FAQ) and `docs/privacy.html` (the IAA data-streaming clause). Left untouched since that's user-facing marketing/legal copy; worth a separate pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
