### PR TITLE
Issue #29: MIDI-in ring lights + CC performance control (app + AUv3)

### DIFF
--- a/MetatoneMIDI/MetatoneMidiManager.h
+++ b/MetatoneMIDI/MetatoneMidiManager.h
@@ -19,6 +19,11 @@
 /// match the prior libpd routing.
 @property (copy, nonatomic) void (^noteOnHandler)(int pitch, int velocity);
 
+/// Invoked on the MIDI thread when a sustain-pedal control change (CC64)
+/// arrives, gated by the `midi_in` user default. `down` = controller value
+/// ≥ 64. Drives the ring-light sustain behaviour (issue #29).
+@property (copy, nonatomic) void (^sustainHandler)(BOOL down);
+
 -(void) setupMidi;
 
 @end

--- a/MetatoneMIDI/MetatoneMidiManager.h
+++ b/MetatoneMIDI/MetatoneMidiManager.h
@@ -24,6 +24,11 @@
 /// ≥ 64. Drives the ring-light sustain behaviour (issue #29).
 @property (copy, nonatomic) void (^sustainHandler)(BOOL down);
 
+/// Invoked on the MIDI thread for control changes other than the sustain pedal,
+/// gated by the `midi_in` user default. Maps to the continuous "sing"
+/// performance receivers (issue #29 follow-up).
+@property (copy, nonatomic) void (^controlChangeHandler)(int cc, int value);
+
 -(void) setupMidi;
 
 @end

--- a/MetatoneMIDI/MetatoneMidiManager.m
+++ b/MetatoneMIDI/MetatoneMidiManager.m
@@ -58,9 +58,12 @@
 {
     const MIDIPacket *packet = &packetList->packet[0];
     for (int i = 0; i < packetList->numPackets; ++i) {
-        if ((packet->length == 3) && ((packet->data[0] & 0xf0) == 0x90) && (packet->data[2] != 0)) {
-            if ([[NSUserDefaults standardUserDefaults] boolForKey:@"midi_in"] && self.noteOnHandler) {
+        if ((packet->length == 3) && [[NSUserDefaults standardUserDefaults] boolForKey:@"midi_in"]) {
+            const UInt8 status = packet->data[0] & 0xf0;
+            if (status == 0x90 && packet->data[2] != 0 && self.noteOnHandler) {
                 self.noteOnHandler(packet->data[1], packet->data[2]);
+            } else if (status == 0xb0 && packet->data[1] == 64 && self.sustainHandler) {
+                self.sustainHandler(packet->data[2] >= 64);   // CC64 sustain pedal
             }
         }
         packet = MIDIPacketNext(packet);

--- a/MetatoneMIDI/MetatoneMidiManager.m
+++ b/MetatoneMIDI/MetatoneMidiManager.m
@@ -62,8 +62,12 @@
             const UInt8 status = packet->data[0] & 0xf0;
             if (status == 0x90 && packet->data[2] != 0 && self.noteOnHandler) {
                 self.noteOnHandler(packet->data[1], packet->data[2]);
-            } else if (status == 0xb0 && packet->data[1] == 64 && self.sustainHandler) {
-                self.sustainHandler(packet->data[2] >= 64);   // CC64 sustain pedal
+            } else if (status == 0xb0) {                       // control change
+                if (packet->data[1] == 64) {
+                    if (self.sustainHandler) self.sustainHandler(packet->data[2] >= 64);  // sustain pedal
+                } else if (self.controlChangeHandler) {
+                    self.controlChangeHandler(packet->data[1], packet->data[2]);
+                }
             }
         }
         packet = MIDIPacketNext(packet);

--- a/PhaseRings/ViewController.m
+++ b/PhaseRings/ViewController.m
@@ -78,6 +78,19 @@
     __weak typeof(self) weakSelf = self;
     self.midiManager.noteOnHandler = ^(int pitch, int velocity) {
         [weakSelf.audioEngine sendNoteOn:1 pitch:pitch velocity:velocity];
+        // Light the matching ring (#29). Fires from the Core MIDI read thread,
+        // so hop to main for UIKit. Gated by the same `midi_in` default as the
+        // audio above (MetatoneMidiManager only calls us when it's enabled).
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [weakSelf.instrument midiNoteIn:pitch velocity:velocity];
+        });
+    };
+    // Sustain pedal (CC64) → ring-light sustain (#29). Visual only; also from
+    // the MIDI thread, so hop to main.
+    self.midiManager.sustainHandler = ^(BOOL down) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [weakSelf.instrument midiSustainPedal:down];
+        });
     };
 
     [self embedInstrument];

--- a/PhaseRings/ViewController.m
+++ b/PhaseRings/ViewController.m
@@ -85,11 +85,17 @@
             [weakSelf.instrument midiNoteIn:pitch velocity:velocity];
         });
     };
-    // Sustain pedal (CC64) → ring-light sustain (#29). Visual only; also from
+    // Sustain pedal (CC64) → gate the "sing" voice + ring sustain (#29). From
     // the MIDI thread, so hop to main.
     self.midiManager.sustainHandler = ^(BOOL down) {
         dispatch_async(dispatch_get_main_queue(), ^{
             [weakSelf.instrument midiSustainPedal:down];
+        });
+    };
+    // Other CCs → the continuous "sing" performance receivers (#29 follow-up).
+    self.midiManager.controlChangeHandler = ^(int cc, int value) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [weakSelf.instrument midiControlChange:cc value:value];
         });
     };
 

--- a/PhaseRingsAUv3/PhaseRingsAUViewController.m
+++ b/PhaseRingsAUv3/PhaseRingsAUViewController.m
@@ -11,6 +11,10 @@
 @interface PhaseRingsAUViewController ()
 @property (nonatomic, strong) PhaseRingsAudioUnit *audioUnit;
 @property (nonatomic, strong) InstrumentViewController *instrument;
+// Polls the AU's incoming-note ring each frame to light rings on host MIDI
+// (#29). Live only while the view is on screen (avoids a CADisplayLink retain
+// cycle and idle ticks when the plugin UI is closed).
+@property (nonatomic, strong, nullable) CADisplayLink *midiInLink;
 @end
 
 @implementation PhaseRingsAUViewController
@@ -24,6 +28,39 @@
     [super viewDidLoad];
     self.preferredContentSize = CGSizeMake(1024, 1024);
     [self embedInstrument];
+}
+
+// Drive the incoming-note → ring-light polling off the view's lifecycle. The
+// link retains its target, so we create it on appear and tear it down on
+// disappear rather than leaking the controller.
+- (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
+    if (!self.midiInLink) {
+        self.midiInLink = [CADisplayLink displayLinkWithTarget:self
+                                                      selector:@selector(drainIncomingMIDI)];
+        [self.midiInLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];
+    }
+}
+
+- (void)viewDidDisappear:(BOOL)animated {
+    [super viewDidDisappear:animated];
+    [self.midiInLink invalidate];
+    self.midiInLink = nil;
+}
+
+- (void)drainIncomingMIDI {
+    __weak PhaseRingsAUViewController *weakSelf = self;
+    [self.audioUnit drainIncomingMIDI:^(uint8_t status, uint8_t d1, uint8_t d2) {
+        InstrumentViewController *instrument = weakSelf.instrument;
+        switch (status & 0xF0) {
+            case 0x90:  // note on (the AU only enqueues velocity > 0)
+                [instrument midiNoteIn:d1 velocity:d2];
+                break;
+            case 0xB0:  // control change
+                if (d1 == 64) [instrument midiSustainPedal:(d2 >= 64)];
+                break;
+        }
+    }];
 }
 
 - (void)embedInstrument {

--- a/PhaseRingsKit/InstrumentViewController.h
+++ b/PhaseRingsKit/InstrumentViewController.h
@@ -94,6 +94,23 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)playbackSwirlAtPoint:(CGPoint)point velocity:(CGFloat)velocity;
 - (void)stopPlayback;
 
+/// MIDI-in ring lights (issue #29): a note arriving from outside the surface
+/// (the app's Core MIDI input, or the AUv3's host) lights the ring carrying
+/// that pitch. Audio for incoming MIDI is produced by the host (the app's
+/// engine / the AU's render block), so this is purely visual and must NOT
+/// re-trigger the core. A note with no matching ring is ignored. Call on the
+/// main thread. `velocity` 0 is ignored (note release is governed by the
+/// sustain pedal, not key-up). Normally the ring flashes once; while the
+/// sustain pedal is held, the first note-on instead lights a pulsing ring that
+/// holds until the pedal lifts (see `midiSustainPedal:`). Velocity is accepted
+/// for future intensity mapping.
+- (void)midiNoteIn:(int)pitch velocity:(int)velocity;
+
+/// MIDI-in sustain pedal (CC64, issue #29). `down` = controller value ≥ 64.
+/// Pressing arms the next note-on to be held as a pulsing ring; lifting stops
+/// the currently held ring. Visual only. Call on the main thread.
+- (void)midiSustainPedal:(BOOL)down;
+
 /// Reflect the current sound scheme (0..6) in the control bar without firing
 /// the handler — e.g. after the host restores AU state.
 - (void)setDisplayedSoundScheme:(NSInteger)scheme;

--- a/PhaseRingsKit/InstrumentViewController.h
+++ b/PhaseRingsKit/InstrumentViewController.h
@@ -96,20 +96,29 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// MIDI-in ring lights (issue #29): a note arriving from outside the surface
 /// (the app's Core MIDI input, or the AUv3's host) lights the ring carrying
-/// that pitch. Audio for incoming MIDI is produced by the host (the app's
-/// engine / the AU's render block), so this is purely visual and must NOT
-/// re-trigger the core. A note with no matching ring is ignored. Call on the
-/// main thread. `velocity` 0 is ignored (note release is governed by the
-/// sustain pedal, not key-up). Normally the ring flashes once; while the
-/// sustain pedal is held, the first note-on instead lights a pulsing ring that
-/// holds until the pedal lifts (see `midiSustainPedal:`). Velocity is accepted
-/// for future intensity mapping.
+/// that pitch. The struck note (`notein`) is produced by the host (the app's
+/// engine / the AU's render block), so this never re-triggers it. A note with
+/// no matching ring is ignored. Call on the main thread. `velocity` 0 is
+/// ignored (note release is governed by the sustain pedal, not key-up).
+/// Normally the ring flashes once; while the sustain pedal is held, the first
+/// note-on instead lights a pulsing ring AND starts the continuous "sing" voice
+/// at that pitch (with `velocity` as the initial level) until the pedal lifts —
+/// see `midiSustainPedal:`. The struck note and the sing voice are independent.
 - (void)midiNoteIn:(int)pitch velocity:(int)velocity;
 
 /// MIDI-in sustain pedal (CC64, issue #29). `down` = controller value ≥ 64.
-/// Pressing arms the next note-on to be held as a pulsing ring; lifting stops
-/// the currently held ring. Visual only. Call on the main thread.
+/// Gates the continuous "sing" voice: pressing arms the next note-on to become
+/// a held sing voice + pulsing ring; lifting stops it. Drives both audio (the
+/// `sing` receiver, via `coreProvider`) and the ring. Call on the main thread.
 - (void)midiSustainPedal:(BOOL)down;
+
+/// MIDI-in control change → the continuous "sing" performance receivers (issue
+/// #29 follow-up): CC11 (expression) → singlevel, CC1 (mod wheel) → sinPanAngle
+/// (bipolar), CC74 (brightness) → panTranslation. Sent to `coreProvider`'s core.
+/// Used by the standalone app; the AUv3 exposes these as automatable AU
+/// parameters (Sing Level / Angle / Morph) and the host maps MIDI to them. Call
+/// on the main thread.
+- (void)midiControlChange:(int)cc value:(int)value;
 
 /// Reflect the current sound scheme (0..6) in the control bar without firing
 /// the handler — e.g. after the host restores AU state.

--- a/PhaseRingsKit/InstrumentViewController.m
+++ b/PhaseRingsKit/InstrumentViewController.m
@@ -38,6 +38,10 @@ static const CGFloat kScreenDiagonal = 1280.0;
 // Remote-OSC playback state (continuous "swirl" with a 1s auto-stop timer).
 @property (nonatomic) int playbackPanGestureState;
 @property (nonatomic, strong, nullable) NSTimer *playbackPanGestureTimeout;
+// MIDI-in sustain pedal (#29): while the pedal is down, the first note-on lights
+// a pulsing (held) ring until the pedal lifts; other notes flash as usual.
+@property (nonatomic) BOOL midiSustainDown;
+@property (nonatomic) int midiSustainedNote;   // -1 = none currently sustained
 @end
 
 // Playback pan states (matches the standalone app's PAN_STATE_* constants).
@@ -52,6 +56,7 @@ static const int kPlaybackStateMoving  = 1;
     [super viewDidLoad];
     self.view.multipleTouchEnabled = YES;
     self.showNoteLabels = YES;
+    self.midiSustainedNote = -1;
 
     // SingingBowlView is transparent in light mode (and paints the solarized
     // teal itself in dark mode), so it relies on a backdrop behind it. Provide
@@ -444,6 +449,33 @@ static const int kPlaybackStateMoving  = 1;
 
 - (int)pitchAtPoint:(CGPoint)point {
     return [self noteFromPosition:point];
+}
+
+#pragma mark - MIDI-in (ring lights)
+
+// Visual only: the host already drives audio for incoming MIDI (the app's
+// engine in its noteOnHandler; the AU's render block via HeavyCoreSendMIDINote).
+// We just light the matching ring, so we never touch `core` here.
+- (void)midiNoteIn:(int)pitch velocity:(int)velocity {
+    if (velocity <= 0) return;   // note-off arrives via the sustain pedal, not here
+    if (self.midiSustainDown && self.midiSustainedNote < 0) {
+        // First note-on since the pedal went down: hold it as a pulsing ring.
+        self.midiSustainedNote = pitch;
+        [self.bowlView continuouslyAnimateBowlForNote:pitch];
+    } else {
+        [self.bowlView animateBowlForNote:pitch];
+    }
+}
+
+// CC64. The sustained ring is released on either pedal edge: pressing arms the
+// next note to be held; lifting stops whatever is held.
+- (void)midiSustainPedal:(BOOL)down {
+    if (down == self.midiSustainDown) return;
+    self.midiSustainDown = down;
+    if (self.midiSustainedNote >= 0) {
+        [self.bowlView stopContinuousAnimationForNote:self.midiSustainedNote];
+        self.midiSustainedNote = -1;
+    }
 }
 
 #pragma mark - Remote-OSC playback

--- a/PhaseRingsKit/InstrumentViewController.m
+++ b/PhaseRingsKit/InstrumentViewController.m
@@ -459,22 +459,44 @@ static const int kPlaybackStateMoving  = 1;
 - (void)midiNoteIn:(int)pitch velocity:(int)velocity {
     if (velocity <= 0) return;   // note-off arrives via the sustain pedal, not here
     if (self.midiSustainDown && self.midiSustainedNote < 0) {
-        // First note-on since the pedal went down: hold it as a pulsing ring.
+        // First note-on since the pedal went down: hold it as a pulsing ring
+        // AND start the continuous "sing" voice at that pitch. The struck note
+        // (notein) still fires via the host, independently — taps and sing are
+        // separate (issue #29).
         self.midiSustainedNote = pitch;
         [self.bowlView continuouslyAnimateBowlForNote:pitch];
+        id<HeavyEventSink> core = [self core];
+        [core sendFloat:(float)pitch toReceiver:@"singpitch"];
+        [core sendFloat:(float)velocity / 127.0f toReceiver:@"singlevel"];  // initial level; CC11 / Sing Level param then modulates
+        [core sendFloat:1 toReceiver:@"sing"];
     } else {
         [self.bowlView animateBowlForNote:pitch];
     }
 }
 
-// CC64. The sustained ring is released on either pedal edge: pressing arms the
-// next note to be held; lifting stops whatever is held.
+// CC64 gates the "sing" voice. A pedal transition (either edge) ends whatever
+// is currently held; pressing then arms the next note-on to become the held
+// sing voice + pulsing ring.
 - (void)midiSustainPedal:(BOOL)down {
     if (down == self.midiSustainDown) return;
     self.midiSustainDown = down;
     if (self.midiSustainedNote >= 0) {
         [self.bowlView stopContinuousAnimationForNote:self.midiSustainedNote];
+        [[self core] sendFloat:0 toReceiver:@"sing"];
         self.midiSustainedNote = -1;
+    }
+}
+
+// Standard CC modulators → the continuous "sing" receivers (issue #29 follow-up,
+// standalone app only; the AUv3 exposes these as host-mappable AU parameters).
+- (void)midiControlChange:(int)cc value:(int)value {
+    id<HeavyEventSink> core = [self core];
+    float v = (float)value / 127.0f;
+    switch (cc) {
+        case 11: [core sendFloat:v toReceiver:@"singlevel"]; break;                    // expression
+        case 1:  [core sendFloat:(v * 2.0f - 1.0f) toReceiver:@"sinPanAngle"]; break;  // mod wheel (bipolar)
+        case 74: [core sendFloat:v toReceiver:@"panTranslation"]; break;               // brightness
+        default: break;
     }
 }
 

--- a/PhaseRingsKit/PhaseRingsAudioUnit.h
+++ b/PhaseRingsKit/PhaseRingsAudioUnit.h
@@ -46,6 +46,14 @@ extern const OSType PhaseRingsAUManufacturer;  // 'CPMa'
 /// advertises a single output port via `MIDIOutputNames`. (Issue #27, B3a.)
 - (void)sendMIDIOutBytes:(const uint8_t *)bytes length:(NSUInteger)length;
 
+/// Drain the MIDI messages received from the host since the last call, invoking
+/// `handler` once per message with the raw status / data bytes (note-ons and
+/// sustain CC; the channel is in the low nibble of `status`). Call from the main
+/// thread; the host UI uses it to light rings on incoming MIDI (issue #29). The
+/// render thread is the producer, so this is a lock-free consumer with no
+/// realtime impact.
+- (void)drainIncomingMIDI:(void (^)(uint8_t status, uint8_t data1, uint8_t data2))handler;
+
 /// AudioComponentDescription for this unit ('aumu' / 'phrg' / 'CPMa').
 + (AudioComponentDescription)componentDescription;
 

--- a/PhaseRingsKit/PhaseRingsAudioUnit.mm
+++ b/PhaseRingsKit/PhaseRingsAudioUnit.mm
@@ -24,6 +24,13 @@ typedef NS_ENUM(AUParameterAddress, PhaseRingsParam) {
     PhaseRingsParamDistortLevel,
     PhaseRingsParamProcessEffects,
     PhaseRingsParamSound,
+    // Continuous "sing" performance controls (#29 follow-up): exposed as
+    // automatable / MIDI-learnable parameters so DAW hosts can replicate the
+    // swirl performance. The standalone app drives the same receivers from a
+    // fixed CC map instead (it has no host).
+    PhaseRingsParamSingLevel,
+    PhaseRingsParamPanAngle,
+    PhaseRingsParamPanTranslation,
 };
 
 // Sound schemes 0..6 (matches the standalone app's Settings `sound`): 0/1 are
@@ -43,6 +50,9 @@ static NSString *ReceiverForParam(AUParameterAddress addr) {
         case PhaseRingsParamReverbVolume:  return @"reverbvolume";
         case PhaseRingsParamDistortLevel:  return @"distortlevel";
         case PhaseRingsParamProcessEffects:return @"processeffects";
+        case PhaseRingsParamSingLevel:     return @"singlevel";
+        case PhaseRingsParamPanAngle:      return @"sinPanAngle";
+        case PhaseRingsParamPanTranslation:return @"panTranslation";
         default: return nil;
     }
 }
@@ -196,7 +206,34 @@ struct AURenderCtx {
         dependentParameters:nil];
     sound.value = 0.0;
 
-    self.parameterTree = [AUParameterTree createTreeWithChildren:@[master, reverb, distort, effects, sound]];
+    // Continuous "sing" performance controls (#29 follow-up). singLevel is the
+    // voice intensity; panAngle (bipolar) and panTranslation are the swirl
+    // timbre morph. Defaults: a mid level so the voice is audible when gated,
+    // neutral timbre. The `sing` gate + `singpitch` are event-driven (sustain
+    // pedal + note), not parameters.
+    AUParameter *singLevel = [AUParameterTree createParameterWithIdentifier:@"singLevel"
+        name:@"Sing Level" address:PhaseRingsParamSingLevel
+        min:0.0 max:1.0 unit:kAudioUnitParameterUnit_LinearGain unitName:nil
+        flags:(kAudioUnitParameterFlag_IsReadable | kAudioUnitParameterFlag_IsWritable)
+        valueStrings:nil dependentParameters:nil];
+    singLevel.value = 0.7;
+
+    AUParameter *panAngle = [AUParameterTree createParameterWithIdentifier:@"panAngle"
+        name:@"Sing Angle" address:PhaseRingsParamPanAngle
+        min:-1.0 max:1.0 unit:kAudioUnitParameterUnit_Generic unitName:nil
+        flags:(kAudioUnitParameterFlag_IsReadable | kAudioUnitParameterFlag_IsWritable)
+        valueStrings:nil dependentParameters:nil];
+    panAngle.value = 0.0;
+
+    AUParameter *panTranslation = [AUParameterTree createParameterWithIdentifier:@"panTranslation"
+        name:@"Sing Morph" address:PhaseRingsParamPanTranslation
+        min:0.0 max:1.0 unit:kAudioUnitParameterUnit_Generic unitName:nil
+        flags:(kAudioUnitParameterFlag_IsReadable | kAudioUnitParameterFlag_IsWritable)
+        valueStrings:nil dependentParameters:nil];
+    panTranslation.value = 0.0;
+
+    self.parameterTree = [AUParameterTree createTreeWithChildren:@[master, reverb, distort, effects, sound,
+                                                                   singLevel, panAngle, panTranslation]];
 
     // Apply parameter changes to the core. Called off the render thread (the
     // setter side); HeavyCore's send paths just enqueue, so this is safe.

--- a/PhaseRingsKit/PhaseRingsAudioUnit.mm
+++ b/PhaseRingsKit/PhaseRingsAudioUnit.mm
@@ -52,6 +52,11 @@ namespace {
 // consumer render thread). Power of two so wrap is a mask.
 constexpr uint32_t kMidiOutCap = 256;
 
+// Capacity of the incoming-note FIFO (single-producer render thread → single-
+// consumer main thread; #29 ring lights). Power of two. Smaller than the
+// output ring: note-ons are sparse and the UI drains it every display frame.
+constexpr uint32_t kMidiInCap = 64;
+
 // Stable, heap-owned state the render block captures. The host guarantees it
 // will not call the render block while render resources are deallocated, so
 // the block only ever sees a valid (or null) refCon. The atomic guards the
@@ -69,6 +74,14 @@ struct AURenderCtx {
     std::atomic<uint32_t> midiTail{0};  // consumer (render)
     // (__bridge) AUMIDIOutputEventBlock, kept alive by the AU's capturedMIDIOut.
     std::atomic<void *> midiSink{nullptr};
+
+    // Incoming MIDI for ring lights (#29): the render thread parses host MIDI
+    // and enqueues raw {status, data1, data2} here (note-ons + sustain CC); the
+    // UI drains on the main thread and interprets. SPSC ring, render = producer,
+    // main = consumer. Drop-on-full (the UI lag, not the note, is what's lost).
+    uint8_t midiIn[kMidiInCap][3];
+    std::atomic<uint32_t> midiInHead{0};  // producer (render)
+    std::atomic<uint32_t> midiInTail{0};  // consumer (main)
 };
 }
 
@@ -267,6 +280,20 @@ struct AURenderCtx {
     _rc->midiHead.store(next, std::memory_order_release);
 }
 
+// Main-thread consumer: hand the UI each MIDI message the render thread
+// enqueued since last call, for ring lights (#29). Mirrors the render block's
+// drain of the outgoing ring.
+- (void)drainIncomingMIDI:(void (^)(uint8_t status, uint8_t data1, uint8_t data2))handler {
+    if (!handler) return;
+    uint32_t tail = _rc->midiInTail.load(std::memory_order_relaxed);
+    uint32_t head = _rc->midiInHead.load(std::memory_order_acquire);
+    while (tail != head) {
+        handler(_rc->midiIn[tail][0], _rc->midiIn[tail][1], _rc->midiIn[tail][2]);
+        tail = (tail + 1) & (kMidiInCap - 1);
+    }
+    _rc->midiInTail.store(tail, std::memory_order_release);
+}
+
 #pragma mark - Render resources
 
 - (BOOL)allocateRenderResourcesAndReturnError:(NSError **)outError {
@@ -375,11 +402,27 @@ struct AURenderCtx {
             if (m->length < 2) continue;
             const uint8_t status = m->data[0] & 0xF0;
             const int channel = (m->data[0] & 0x0F) + 1;  // 1-based, matches the app
+            const uint8_t d1 = m->data[1];
+            const uint8_t d2 = (m->length >= 3) ? m->data[2] : 0;
             if (status == 0x90) {  // note on (velocity 0 == note off)
-                const int vel = (m->length >= 3) ? m->data[2] : 0;
-                HeavyCoreSendMIDINote(refCon, m->data[1], vel, channel);
+                HeavyCoreSendMIDINote(refCon, d1, d2, channel);
             } else if (status == 0x80) {  // note off
-                HeavyCoreSendMIDINote(refCon, m->data[1], 0, channel);
+                HeavyCoreSendMIDINote(refCon, d1, 0, channel);
+            }
+            // Surface note-ons and the sustain pedal (CC64) to the UI for ring
+            // lights (#29). Note-offs aren't needed (flashes self-fade; sustain
+            // holds until the pedal lifts).
+            const bool wantUI = (status == 0x90 && d2 > 0) ||
+                                (status == 0xB0 && d1 == 64);
+            if (wantUI) {
+                uint32_t h = rc->midiInHead.load(std::memory_order_relaxed);
+                uint32_t n = (h + 1) & (kMidiInCap - 1);
+                if (n != rc->midiInTail.load(std::memory_order_acquire)) {  // not full
+                    rc->midiIn[h][0] = m->data[0];   // full status byte (with channel)
+                    rc->midiIn[h][1] = d1;
+                    rc->midiIn[h][2] = d2;
+                    rc->midiInHead.store(n, std::memory_order_release);
+                }
             }
         }
 

--- a/PhaseRingsKit/SingingBowlView.h
+++ b/PhaseRingsKit/SingingBowlView.h
@@ -20,8 +20,20 @@
 
 /*! Starts the tap animation for a single ring. */
 -(void) animateBowlAtRadius:(CGFloat)radius;
+/*! Starts the tap animation for the ring carrying a given MIDI note number.
+    No-op if the note is not present in the current setup. Used to light rings
+    from incoming MIDI (issue #29); the radius variant resolves to this. */
+-(void) animateBowlForNote:(int)note;
 /*! Starts the swirl animation for a single ring. */
 -(void) continuouslyAnimateBowlAtRadius:(CGFloat) radius;
+/*! Starts the pulsing (held) animation for the ring carrying a given MIDI note
+    number, made visible directly (no volume gesture drives it). Used for
+    sustain-pedal held notes from incoming MIDI (issue #29). No-op if the note
+    is not present in the current setup. */
+-(void) continuouslyAnimateBowlForNote:(int)note;
+/*! Stops the pulsing animation for a single ring by MIDI note number, fading it
+    out. Counterpart to continuouslyAnimateBowlForNote:. */
+-(void) stopContinuousAnimationForNote:(int)note;
 /*! Adjusts the "volume" (opacity) of the currently animated ring.*/
 -(void) changeBowlVolumeTo:(CGFloat) level;
 /*! Adjusts the speed of the currently animated ring.*/

--- a/PhaseRingsKit/SingingBowlView.m
+++ b/PhaseRingsKit/SingingBowlView.m
@@ -212,9 +212,13 @@
 #pragma mark - UI Methods
 -(void) animateBowlAtRadius:(CGFloat)radius {
     CGFloat fracRadius = [self fractionOfTotalRadiusFromRadius:radius];
-    int note = [self.currentSetup pitchAtRadius:fracRadius];
+    [self animateBowlForNote:[self.currentSetup pitchAtRadius:fracRadius]];
+}
+
+-(void) animateBowlForNote:(int)note {
     CAShapeLayer *layer = [self.tapEdgeLayers objectForKey:
                            [NSNumber numberWithInt:note]];
+    if (!layer) return;   // note not in the current setup: nothing to light
     [CATransaction flush];
     [CATransaction begin];
     //NSLog(@"Current duration: %f", [CATransaction animationDuration]);
@@ -235,17 +239,47 @@
     CAShapeLayer *layer = [self.continuousEdgeLayers objectForKey:
                            [NSNumber numberWithInt:[self.currentSetup pitchAtRadius:
                             [self fractionOfTotalRadiusFromRadius:radius]]]];
-    CGFloat width = layer.lineWidth;
+    // Opacity is driven by the swirl gesture's changeBowlVolumeTo:.
     layer.hidden = NO;
-    
+    [self addPulseAnimationToLayer:layer];
+}
+
+// Shared pulse used by the swirl gesture and by MIDI sustain (#29): grow/shrink
+// the ring's line width forever until it's stopped/hidden.
+-(void) addPulseAnimationToLayer:(CAShapeLayer *)layer {
+    if (!layer) return;
+    CGFloat width = layer.lineWidth;
     CABasicAnimation *pulse = [CABasicAnimation animationWithKeyPath:@"lineWidth"];
     pulse.fromValue = [NSNumber numberWithDouble:width * 0.90];
     pulse.toValue = [NSNumber numberWithDouble:width * 1.10];
     pulse.duration = 0.15;
     pulse.autoreverses = YES;
     pulse.repeatCount = HUGE_VALF;
-    
     [layer addAnimation:pulse forKey:@"pulseAnimation"];
+}
+
+-(void) continuouslyAnimateBowlForNote:(int)note {
+    CAShapeLayer *layer = [self.continuousEdgeLayers objectForKey:
+                           [NSNumber numberWithInt:note]];
+    if (!layer) return;   // note not in the current setup
+    // No volume gesture drives this, so make the ring visible directly.
+    layer.hidden = NO;
+    layer.opacity = 1.0;
+    [self addPulseAnimationToLayer:layer];
+}
+
+-(void) stopContinuousAnimationForNote:(int)note {
+    CAShapeLayer *layer = [self.continuousEdgeLayers objectForKey:
+                           [NSNumber numberWithInt:note]];
+    if (!layer || layer.hidden) return;
+    [CATransaction begin];
+    [CATransaction setAnimationDuration:0.3];
+    [CATransaction setCompletionBlock:^{
+        layer.hidden = YES;
+        [layer removeAnimationForKey:@"pulseAnimation"];
+    }];
+    layer.opacity = 0.0;
+    [CATransaction commit];
 }
 
 -(void) stopAnimatingBowl {

--- a/PhaseRingsTests/SharedSurfaceTests.m
+++ b/PhaseRingsTests/SharedSurfaceTests.m
@@ -215,6 +215,46 @@
     XCTAssertEqualObjects([_sink lastFloatFor:@"singlevel"], @0);
 }
 
+#pragma mark - MIDI-in (ring lights + sing performance)
+
+- (void)testMidiNoteInWithoutPedalDoesNotSing {
+    [_vc midiNoteIn:60 velocity:100];
+    XCTAssertNil([_sink lastFloatFor:@"sing"]);          // a bare note-on only flashes a ring
+    XCTAssertNil([_sink lastFloatFor:@"singpitch"]);
+    XCTAssertEqual(_sink.noteOns.count, (NSUInteger)0);  // the struck note is the host's job, not the surface
+}
+
+- (void)testSustainPedalGatesSingVoice {
+    [_vc midiSustainPedal:YES];
+    [_vc midiNoteIn:62 velocity:100];
+    XCTAssertEqualObjects([_sink lastFloatFor:@"sing"], @1);
+    XCTAssertEqualWithAccuracy([_sink lastFloatFor:@"singpitch"].floatValue, 62.0, 0.0001);
+    XCTAssertEqualWithAccuracy([_sink lastFloatFor:@"singlevel"].floatValue, 100.0 / 127.0, 0.0001);
+
+    [_vc midiSustainPedal:NO];
+    XCTAssertEqualObjects([_sink lastFloatFor:@"sing"], @0);   // pedal up ends the voice
+}
+
+- (void)testFirstNoteAfterPedalSingsAndLaterNotesDoNotResing {
+    [_vc midiSustainPedal:YES];
+    [_vc midiNoteIn:62 velocity:100];   // first note: captured as the sing pitch
+    [_vc midiNoteIn:67 velocity:100];   // later note while held: must not re-pitch the voice
+    XCTAssertEqualWithAccuracy([_sink lastFloatFor:@"singpitch"].floatValue, 62.0, 0.0001);
+}
+
+- (void)testControlChangeMapsToSingReceivers {
+    [_vc midiControlChange:11 value:64];   // expression → singlevel
+    XCTAssertEqualWithAccuracy([_sink lastFloatFor:@"singlevel"].floatValue, 64.0 / 127.0, 0.0001);
+
+    [_vc midiControlChange:1 value:127];   // mod wheel → sinPanAngle (bipolar)
+    XCTAssertEqualWithAccuracy([_sink lastFloatFor:@"sinPanAngle"].floatValue, 1.0, 0.0001);
+    [_vc midiControlChange:1 value:0];
+    XCTAssertEqualWithAccuracy([_sink lastFloatFor:@"sinPanAngle"].floatValue, -1.0, 0.0001);
+
+    [_vc midiControlChange:74 value:127];  // brightness → panTranslation
+    XCTAssertEqualWithAccuracy([_sink lastFloatFor:@"panTranslation"].floatValue, 1.0, 0.0001);
+}
+
 - (void)testShowSetupStateClamps {
     NSInteger n = _vc.numberOfSetups;
     XCTAssertGreaterThan(n, 0);


### PR DESCRIPTION
Closes #29.

MIDI-in already produced sound in both the standalone app and the AUv3 plugin, but gave no visual feedback and couldn't reach the continuous *swirl/sing* performance. This adds, shared across both hosts:

1. **Ring lights** on incoming notes.
2. **CC control of the continuous "sing" performance**, so a controller can replicate swirl sounds — not just strike notes.

## Ring lights
- **Note-on** flashes the ring carrying that pitch (no `notein` re-trigger — the host already drives struck audio).
- A note with no matching ring is ignored. The animation layers were already keyed by MIDI note number, so no pitch→radius inversion is needed.

## Sustain pedal + sing performance
- **Sustain pedal (CC64)** gates the `sing` voice. While held, the **first note-on** becomes the sustained sing pitch — the *same* note this PR pulses as a ring, so the pulsing ring and the audible pitch line up — with velocity as the initial level. Pedal-up ends it. Later notes while held flash + strike as usual. **Sing and struck notes are independent.**
- **CC modulators:** CC11 (expression)→`singlevel`, CC1 (mod wheel)→`sinPanAngle` (bipolar), CC74 (brightness)→`panTranslation`.
- **AUv3:** the three modulators are exposed as automatable **AU parameters** (Sing Level / Angle / Morph) so DAW hosts can automate or MIDI-learn them. The **standalone app** uses the fixed CC map (it has no host). Gate + pitch are event-driven through the shared surface in both hosts.

## Wiring
- **`InstrumentViewController`** — shared seam: `midiNoteIn:velocity:`, `midiSustainPedal:`, `midiControlChange:value:`. Drives the core via `coreProvider`; never re-triggers the struck note.
- **`SingingBowlView`** — note-keyed `animateBowlForNote:` (flash) and `continuouslyAnimateBowlForNote:` / `stopContinuousAnimationForNote:` (held pulse), pulse refactored into a shared helper; touch-swirl path unchanged.
- **App** — `MetatoneMidiManager` gains `sustainHandler` + `controlChangeHandler` (gated by `midi_in`); `ViewController` hops them to main.
- **AUv3** — render thread enqueues note-ons + CC64 into a lock-free SPSC ring; a `CADisplayLink` (live only on-screen) drains it on main and routes to the seam. The three modulator CCs are handled by the host via the AU parameters. Ring lights always-on, no toggle.

## Decisions
- `midi_in` toggle: **kept for the app, always-on for AUv3**.
- `singpitch` from the **first note-on after pedal-down** (matches the pulsing ring).
- Note-off intentionally not plumbed — the held voice/ring release on pedal-up, not key-up; flashes self-fade.

## Testing
- Builds clean for the iOS Simulator across the app, `PhaseRingsKit.framework`, and the AUv3 extension.
- 4 new `InstrumentSurfaceTests` (no-pedal flash sends no sing; pedal gates the voice; first-note-after-pedal capture; CC map) — full `InstrumentSurfaceTests` suite green (13/13).
- Not yet exercised live in a host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)