### PR TITLE
Issue #37: multi-observer PRSettingsStore — sheet no longer steals the surface's callback

### DIFF
--- a/PhaseRings/PRUserDefaultsStore.m
+++ b/PhaseRings/PRUserDefaultsStore.m
@@ -4,6 +4,7 @@
 //
 
 #import "PRUserDefaultsStore.h"
+#import <PhaseRingsKit/PRSettingsObserverSet.h>
 
 // Existing NSUserDefaults keys (see Settings.bundle + AppDelegate registerDefaults).
 static NSString *const kSound          = @"sound";
@@ -23,11 +24,10 @@ static NSString *const kScale3         = @"scale_3";
 
 @interface PRUserDefaultsStore ()
 @property (nonatomic, strong) NSUserDefaults *defaults;
+@property (nonatomic, strong) PRSettingsObserverSet *observers;
 @end
 
 @implementation PRUserDefaultsStore
-
-@synthesize onChange = _onChange;
 
 - (instancetype)init {
     return [self initWithUserDefaults:[NSUserDefaults standardUserDefaults]];
@@ -37,8 +37,17 @@ static NSString *const kScale3         = @"scale_3";
     self = [super init];
     if (self) {
         _defaults = defaults;
+        _observers = [[PRSettingsObserverSet alloc] init];
     }
     return self;
+}
+
+- (id)addSettingsObserver:(void (^)(PRSettings *))observer {
+    return [self.observers addObserver:observer];
+}
+
+- (void)removeSettingsObserver:(id)token {
+    [self.observers removeObserver:token];
 }
 
 - (PRSettings *)currentSettings {
@@ -82,9 +91,7 @@ static NSString *const kScale3         = @"scale_3";
     [d setInteger:s.scale2         forKey:kScale2];
     [d setInteger:s.scale3         forKey:kScale3];
 
-    if (self.onChange) {
-        self.onChange([s copy]);
-    }
+    [self.observers notifyAll:[s copy]];
 }
 
 @end

--- a/PhaseRings/ViewController.m
+++ b/PhaseRings/ViewController.m
@@ -262,7 +262,7 @@
 // Any NSUserDefaults change (in-app sheet or the iOS Settings.app pane): push
 // the volume/effects levels to the engine, and let the surface re-apply
 // composition / sound / labels non-disruptively. For in-app-sheet edits the
-// surface already updated via the store's onChange, so this is a cheap no-op.
+// surface already updated via its store observer, so this is a cheap no-op.
 //
 // NSUserDefaultsDidChangeNotification fires once per set* call, and
 // PRUserDefaultsStore writes all 14 keys per edit — so a single sheet edit

--- a/PhaseRingsKit/InstrumentViewController.h
+++ b/PhaseRingsKit/InstrumentViewController.h
@@ -130,7 +130,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// Re-read the settings store and apply any changes non-disruptively (rebuild
 /// only if the composition changed; otherwise just re-apply labels/sound). A
 /// host calls this when settings may have changed outside the in-app sheet
-/// (e.g. the iOS Settings.app pane) so the store's `onChange` did not fire.
+/// (e.g. the iOS Settings.app pane) so the store's observers did not fire.
 - (void)applyCurrentSettings;
 
 @end

--- a/PhaseRingsKit/InstrumentViewController.m
+++ b/PhaseRingsKit/InstrumentViewController.m
@@ -35,6 +35,9 @@ static const CGFloat kScreenDiagonal = 1280.0;
 @property (nonatomic, strong) UILabel *setupDescriptionLabel;
 // Last settings applied, so a settings change only rebuilds what actually moved.
 @property (nonatomic, strong) PRSettings *appliedSettings;
+// Token from the store's addSettingsObserver: (issue #37 — observers are
+// token-registered now, so the settings sheet's model can't clobber ours).
+@property (nonatomic, strong, nullable) id settingsObserverToken;
 // Remote-OSC playback state (continuous "swirl" with a 1s auto-stop timer).
 @property (nonatomic) int playbackPanGestureState;
 @property (nonatomic, strong, nullable) NSTimer *playbackPanGestureTimeout;
@@ -87,20 +90,25 @@ static const int kPlaybackStateMoving  = 1;
 
 - (id<PRSettingsStore>)settingsStore {
     if (!_settingsStore) {
-        self.settingsStore = [[PRMemoryStore alloc] init];  // through setter -> wires onChange
+        self.settingsStore = [[PRMemoryStore alloc] init];  // through setter -> registers observer
     }
     return _settingsStore;
 }
 
 - (void)setSettingsStore:(id<PRSettingsStore>)settingsStore {
+    [_settingsStore removeSettingsObserver:_settingsObserverToken];
     _settingsStore = settingsStore;
     __weak typeof(self) weakSelf = self;
-    settingsStore.onChange = ^(PRSettings *settings) {
+    _settingsObserverToken = [settingsStore addSettingsObserver:^(PRSettings *settings) {
         [weakSelf settingsDidChange:settings];
-    };
+    }];
     if (self.isViewLoaded) {
         [self reloadComposition];
     }
+}
+
+- (void)dealloc {
+    [_settingsStore removeSettingsObserver:_settingsObserverToken];
 }
 
 #pragma mark - Control bar
@@ -150,7 +158,7 @@ static const int kPlaybackStateMoving  = 1;
 }
 
 - (void)showSettingsTapped {
-    // Edits flow through the store live (onChange -> -settingsDidChange:), so no
+    // Edits flow through the store live (observer -> -settingsDidChange:), so no
     // reload-on-dismiss is needed here.
     PRSettingsHostingController *settings =
         [[PRSettingsHostingController alloc] initWithStore:self.settingsStore];

--- a/PhaseRingsKit/PRAudioUnitStore.m
+++ b/PhaseRingsKit/PRAudioUnitStore.m
@@ -5,6 +5,7 @@
 
 #import "PRAudioUnitStore.h"
 #import "PRSettings.h"
+#import "PRSettingsObserverSet.h"
 #import "PhaseRingsAudioUnit.h"
 #import <AudioToolbox/AudioToolbox.h>
 
@@ -31,26 +32,34 @@ static NSString *const kScale3      = @"scale3";
 
 @interface PRAudioUnitStore ()
 @property (nonatomic, weak) PhaseRingsAudioUnit *audioUnit;
+@property (nonatomic, strong) PRSettingsObserverSet *observers;
 @end
 
 @implementation PRAudioUnitStore
-
-@synthesize onChange = _onChange;
 
 - (instancetype)initWithAudioUnit:(PhaseRingsAudioUnit *)audioUnit {
     self = [super init];
     if (self) {
         _audioUnit = audioUnit;
+        _observers = [[PRSettingsObserverSet alloc] init];
         // Rebroadcast host state restores (fullState) to the UI.
         __weak typeof(self) weakSelf = self;
         audioUnit.instrumentStateRestoredHandler = ^{
             typeof(self) strongSelf = weakSelf;
-            if (strongSelf.onChange) {
-                strongSelf.onChange([strongSelf currentSettings]);
+            if (strongSelf) {
+                [strongSelf.observers notifyAll:[strongSelf currentSettings]];
             }
         };
     }
     return self;
+}
+
+- (id)addSettingsObserver:(void (^)(PRSettings *))observer {
+    return [self.observers addObserver:observer];
+}
+
+- (void)removeSettingsObserver:(id)token {
+    [self.observers removeObserver:token];
 }
 
 - (float)param:(AUParameterAddress)address {
@@ -112,9 +121,7 @@ static NSString *const kScale3      = @"scale3";
         kScale3:      @(s.scale3),
     };
 
-    if (self.onChange) {
-        self.onChange([s copy]);
-    }
+    [self.observers notifyAll:[s copy]];
 }
 
 @end

--- a/PhaseRingsKit/PRMemoryStore.m
+++ b/PhaseRingsKit/PRMemoryStore.m
@@ -4,17 +4,18 @@
 //
 
 #import "PRMemoryStore.h"
+#import "PRSettingsObserverSet.h"
 
 @implementation PRMemoryStore {
     PRSettings *_settings;
+    PRSettingsObserverSet *_observers;
 }
-
-@synthesize onChange = _onChange;
 
 - (instancetype)init {
     self = [super init];
     if (self) {
         _settings = [PRSettings defaultSettings];
+        _observers = [[PRSettingsObserverSet alloc] init];
     }
     return self;
 }
@@ -29,9 +30,15 @@
         mutations(s);
     }
     _settings = [s copy];
-    if (self.onChange) {
-        self.onChange([_settings copy]);
-    }
+    [_observers notifyAll:[_settings copy]];
+}
+
+- (id)addSettingsObserver:(void (^)(PRSettings *))observer {
+    return [_observers addObserver:observer];
+}
+
+- (void)removeSettingsObserver:(id)token {
+    [_observers removeObserver:token];
 }
 
 @end

--- a/PhaseRingsKit/PRSettingsModel.swift
+++ b/PhaseRingsKit/PRSettingsModel.swift
@@ -17,8 +17,12 @@ import Combine
 public final class PRSettingsModel: NSObject, ObservableObject {
 
     private let store: PRSettingsStore
-    // Suppresses store writes while we're ingesting a snapshot (load / onChange),
-    // so republishing doesn't bounce back into the store.
+    // Token from the store's addSettingsObserver: (issue #37 — registering as
+    // one observer among many, instead of stealing the instrument surface's
+    // old single-slot `onChange` callback).
+    private var observerToken: Any?
+    // Suppresses store writes while we're ingesting a snapshot (load / observer
+    // callback), so republishing doesn't bounce back into the store.
     private var isSyncing = false
 
     @Published public var sound: Int { didSet { push() } }
@@ -55,9 +59,13 @@ public final class PRSettingsModel: NSObject, ObservableObject {
         scale3 = s.scale3
         super.init()
 
-        store.onChange = { [weak self] snapshot in
+        observerToken = store.addSettingsObserver { [weak self] snapshot in
             self?.ingest(snapshot)
         }
+    }
+
+    deinit {
+        store.removeSettingsObserver(observerToken)
     }
 
     /// Pull a store snapshot into the published properties without writing back.

--- a/PhaseRingsKit/PRSettingsObserverSet.h
+++ b/PhaseRingsKit/PRSettingsObserverSet.h
@@ -1,0 +1,32 @@
+//
+//  PRSettingsObserverSet.h
+//  PhaseRingsKit
+//
+//  Issue #37: shared observer bookkeeping for PRSettingsStore implementations.
+//  Replaces the protocol's old single-slot `onChange` callback, which a second
+//  observer silently clobbered (the settings sheet's PRSettingsModel stole the
+//  instrument surface's slot, permanently disconnecting it).
+//
+
+#import <Foundation/Foundation.h>
+#import "PRSettings.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Token-keyed collection of settings observers. Each store owns one and
+/// forwards its add/remove/notify. Observers are notified in registration
+/// order. Not thread-safe — stores fire on the main thread.
+@interface PRSettingsObserverSet : NSObject
+
+/// Register an observer block; returns an opaque token for `removeObserver:`.
+- (id)addObserver:(void (^)(PRSettings *settings))observer;
+
+/// Unregister a token from `addObserver:`. `nil` or an unknown token is a no-op.
+- (void)removeObserver:(nullable id)token;
+
+/// Invoke every registered observer with `settings`.
+- (void)notifyAll:(PRSettings *)settings;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/PhaseRingsKit/PRSettingsObserverSet.m
+++ b/PhaseRingsKit/PRSettingsObserverSet.m
@@ -1,0 +1,48 @@
+//
+//  PRSettingsObserverSet.m
+//  PhaseRingsKit
+//
+
+#import "PRSettingsObserverSet.h"
+
+@implementation PRSettingsObserverSet {
+    NSMutableArray<NSUUID *> *_tokens;   // registration order
+    NSMutableDictionary<NSUUID *, void (^)(PRSettings *)> *_observers;
+}
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        _tokens = [NSMutableArray array];
+        _observers = [NSMutableDictionary dictionary];
+    }
+    return self;
+}
+
+- (id)addObserver:(void (^)(PRSettings *))observer {
+    NSUUID *token = [NSUUID UUID];
+    [_tokens addObject:token];
+    _observers[token] = [observer copy];
+    return token;
+}
+
+- (void)removeObserver:(id)token {
+    if (!token) {
+        return;
+    }
+    [_tokens removeObject:token];
+    [_observers removeObjectForKey:token];
+}
+
+- (void)notifyAll:(PRSettings *)settings {
+    // Snapshot first so an observer adding/removing during notification
+    // doesn't mutate the collection mid-iteration.
+    for (NSUUID *token in [_tokens copy]) {
+        void (^observer)(PRSettings *) = _observers[token];
+        if (observer) {
+            observer(settings);
+        }
+    }
+}
+
+@end

--- a/PhaseRingsKit/PRSettingsStore.h
+++ b/PhaseRingsKit/PRSettingsStore.h
@@ -20,13 +20,20 @@ NS_ASSUME_NONNULL_BEGIN
 - (PRSettings *)currentSettings;
 
 /// Mutate-and-persist. The block receives a mutable copy of the current
-/// settings; whatever it leaves is persisted by the host and then broadcast via
-/// `onChange`.
+/// settings; whatever it leaves is persisted by the host and then broadcast to
+/// every registered observer.
 - (void)updateSettings:(void (^)(PRSettings *settings))mutations;
 
-/// Fired after the settings change (whether via `updateSettings:` or an external
-/// edit the host detects). Carries a snapshot of the new state.
-@property (nonatomic, copy, nullable) void (^onChange)(PRSettings *settings);
+/// Register to be notified after the settings change (whether via
+/// `updateSettings:` or an external edit the host detects). The block carries a
+/// snapshot of the new state. Returns an opaque token for
+/// `removeSettingsObserver:`. Multiple observers may be registered at once
+/// (issue #37 — the instrument surface and the settings sheet's model observe
+/// concurrently; the old single-slot `onChange` let one clobber the other).
+- (id)addSettingsObserver:(void (^)(PRSettings *settings))observer;
+
+/// Unregister a token from `addSettingsObserver:`. `nil` is a no-op.
+- (void)removeSettingsObserver:(nullable id)token;
 
 @end
 

--- a/PhaseRingsKit/PhaseRingsKit.h
+++ b/PhaseRingsKit/PhaseRingsKit.h
@@ -20,6 +20,7 @@ FOUNDATION_EXPORT const unsigned char PhaseRingsKitVersionString[];
 #import <PhaseRingsKit/InstrumentViewController.h>
 #import <PhaseRingsKit/PRSettings.h>
 #import <PhaseRingsKit/PRSettingsStore.h>
+#import <PhaseRingsKit/PRSettingsObserverSet.h>
 #import <PhaseRingsKit/PRMemoryStore.h>
 #import <PhaseRingsKit/PRAudioUnitStore.h>
 #import <PhaseRingsKit/PRCompositionFactory.h>

--- a/PhaseRingsTests/PRSettingsTests.m
+++ b/PhaseRingsTests/PRSettingsTests.m
@@ -11,6 +11,7 @@
 
 #import <XCTest/XCTest.h>
 #import <PhaseRingsKit/PhaseRingsKit.h>
+#import <PhaseRingsKit/PhaseRingsKit-Swift.h>   // PRSettingsModel
 #import "GenerativeSetupComposition.h"
 #import "PRUserDefaultsStore.h"
 
@@ -112,11 +113,11 @@ static const NSInteger kBaseA = 33;
     [d removePersistentDomainForName:suite];
     PRUserDefaultsStore *store = [[PRUserDefaultsStore alloc] initWithUserDefaults:d];
 
-    XCTestExpectation *fired = [self expectationWithDescription:@"onChange"];
-    store.onChange = ^(PRSettings *s) {
+    XCTestExpectation *fired = [self expectationWithDescription:@"observer"];
+    [store addSettingsObserver:^(PRSettings *s) {
         XCTAssertEqual(s.sound, 4);
         [fired fulfill];
-    };
+    }];
     [store updateSettings:^(PRSettings *s) { s.sound = 4; }];
     [self waitForExpectations:@[fired] timeout:1.0];
 
@@ -153,13 +154,61 @@ static const NSInteger kBaseA = 33;
 
 - (void)testMemoryStoreFiresOnChange {
     PRMemoryStore *store = [[PRMemoryStore alloc] init];
-    XCTestExpectation *fired = [self expectationWithDescription:@"onChange"];
-    store.onChange = ^(PRSettings *s) {
+    XCTestExpectation *fired = [self expectationWithDescription:@"observer"];
+    [store addSettingsObserver:^(PRSettings *s) {
         XCTAssertEqual(s.sound, 5);
         [fired fulfill];
-    };
+    }];
     [store updateSettings:^(PRSettings *s) { s.sound = 5; }];
     [self waitForExpectations:@[fired] timeout:1.0];
+}
+
+#pragma mark - Multi-observer store notifications (issue #37)
+
+- (void)testMultipleObserversAllFire {
+    PRMemoryStore *store = [[PRMemoryStore alloc] init];
+    __block NSInteger first = 0, second = 0;
+    [store addSettingsObserver:^(PRSettings *s) { first++; }];
+    [store addSettingsObserver:^(PRSettings *s) { second++; }];
+    [store updateSettings:^(PRSettings *s) { s.sound = 2; }];
+    XCTAssertEqual(first, 1, @"registering a second observer must not clobber the first");
+    XCTAssertEqual(second, 1);
+}
+
+- (void)testRemovedObserverStopsFiringOthersUnaffected {
+    PRMemoryStore *store = [[PRMemoryStore alloc] init];
+    __block NSInteger kept = 0, removed = 0;
+    [store addSettingsObserver:^(PRSettings *s) { kept++; }];
+    id token = [store addSettingsObserver:^(PRSettings *s) { removed++; }];
+    [store removeSettingsObserver:token];
+    [store removeSettingsObserver:nil];  // nil token is a no-op
+    [store updateSettings:^(PRSettings *s) { s.sound = 2; }];
+    XCTAssertEqual(kept, 1);
+    XCTAssertEqual(removed, 0);
+}
+
+// The issue #37 scenario end-to-end: the instrument surface observes the store,
+// the settings sheet's PRSettingsModel comes and goes; the surface keeps
+// receiving change notifications throughout and afterwards. (The model's
+// @Published properties aren't ObjC-visible, so the store is driven directly;
+// the regression was the model's registration clobbering the surface's slot.)
+- (void)testSettingsModelLifecycleDoesNotDisconnectOtherObservers {
+    PRMemoryStore *store = [[PRMemoryStore alloc] init];
+    __block NSInteger surfaceNotified = 0;
+    [store addSettingsObserver:^(PRSettings *s) { surfaceNotified++; }];
+
+    @autoreleasepool {
+        PRSettingsModel *model = [[PRSettingsModel alloc] initWithStore:store];
+        XCTAssertNotNil(model);
+        // Sheet open: a store change must still reach the surface.
+        [store updateSettings:^(PRSettings *s) { s.sound = 3; }];
+        XCTAssertEqual(surfaceNotified, 1, @"opening the sheet must not steal the surface's observer");
+    }
+
+    // Sheet dismissed (model deallocated): host-driven changes still reach the
+    // surface — this was the AUv3 breakage in issue #37.
+    [store updateSettings:^(PRSettings *s) { s.sound = 4; }];
+    XCTAssertEqual(surfaceNotified, 2, @"surface must keep observing after the sheet is gone");
 }
 
 @end

--- a/PhaseRingsTests/PhaseRingsAudioUnitTests.m
+++ b/PhaseRingsTests/PhaseRingsAudioUnitTests.m
@@ -244,11 +244,11 @@
 
     PhaseRingsAudioUnit *au2 = [self makeUnit];
     PRAudioUnitStore *store2 = [[PRAudioUnitStore alloc] initWithAudioUnit:au2];
-    XCTestExpectation *fired = [self expectationWithDescription:@"onChange after restore"];
-    store2.onChange = ^(PRSettings *s) {
+    XCTestExpectation *fired = [self expectationWithDescription:@"observer fires after restore"];
+    [store2 addSettingsObserver:^(PRSettings *s) {
         XCTAssertEqual(s.composition, 3);
         [fired fulfill];
-    };
+    }];
     [au2 setFullState:full];  // restore handler is dispatched to the main queue
     [self waitForExpectations:@[fired] timeout:1.0];
 }

--- a/project.yml
+++ b/project.yml
@@ -102,6 +102,7 @@ targets:
           - "PRCompositionFactory.h"
           - "PRMemoryStore.h"
           - "PRSettings.h"
+          - "PRSettingsObserverSet.h"
           - "PRSettingsStore.h"
           - "PhaseRingsAudioUnit.h"
           - "PhaseRingsKit.h"
@@ -116,6 +117,7 @@ targets:
       - { path: PhaseRingsKit/InstrumentViewController.h, headerVisibility: public }
       - { path: PhaseRingsKit/PRSettings.h, headerVisibility: public }
       - { path: PhaseRingsKit/PRSettingsStore.h, headerVisibility: public }
+      - { path: PhaseRingsKit/PRSettingsObserverSet.h, headerVisibility: public }
       - { path: PhaseRingsKit/PRCompositionFactory.h, headerVisibility: public }
       - { path: PhaseRingsKit/PRMemoryStore.h, headerVisibility: public }
       - { path: PhaseRingsKit/PRAudioUnitStore.h, headerVisibility: public }


### PR DESCRIPTION
Closes #37.

## Problem

`PRSettingsStore` had a single `onChange` callback slot. `InstrumentViewController.setSettingsStore:` claims it to apply settings live, but `PRSettingsModel.init` **replaced** it with its own ingest closure — so tapping the settings gear permanently disconnected the instrument surface from the store, leaving the slot pointing at a dead weak-self closure after the sheet was dismissed.

- **Standalone app:** masked by the separate `NSUserDefaultsDidChangeNotification` → `-applyCurrentSettings` path.
- **AUv3:** the store's callback is the *only* channel from `PRAudioUnitStore` to the surface — after the first gear tap, sheet edits and host-driven changes (including `fullState` restores) never reached `-settingsDidChange:` / `applySoundScheme` again.

## Fix

The robust option from the issue: proper multi-observer support instead of callback chaining (which would accumulate a dead wrapper per gear tap).

- **Protocol**: `onChange` is gone, replaced by token-based `addSettingsObserver:` / `removeSettingsObserver:` so a second observer can't clobber the first.
- **New `PRSettingsObserverSet`** (public PhaseRingsKit header): shared observer bookkeeping — registration-ordered, snapshot-before-notify — owned by all three stores (`PRMemoryStore`, `PRUserDefaultsStore`, `PRAudioUnitStore`). The AU store's state-restore handler notifies all observers too.
- **`InstrumentViewController`** registers via token, detaching from a replaced store and in `dealloc`.
- **`PRSettingsModel`** registers as a peer in `init` and removes itself in `deinit`.

## Tests

Three new regression tests in `PRSettingsTests`:
- `testMultipleObserversAllFire` — second observer doesn't clobber the first
- `testRemovedObserverStopsFiringOthersUnaffected` — removal is isolated; nil token is a no-op
- `testSettingsModelLifecycleDoesNotDisconnectOtherObservers` — the #37 scenario end-to-end: surface observes, sheet model created, store edit still reaches the surface; model deallocated, host-driven change still reaches the surface

Full suite on iPad Pro 11" simulator: **79 tests, 0 failures** (4 pre-existing #25 skips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)