### PR TITLE
Issue #35: let taps land while swirling (pan must not swallow touches)

### DIFF
--- a/PhaseRingsKit/InstrumentViewController.m
+++ b/PhaseRingsKit/InstrumentViewController.m
@@ -80,6 +80,13 @@ static const int kPlaybackStateMoving  = 1;
 
     UIPanGestureRecognizer *pan =
         [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(panGestureRecognized:)];
+    // Issue #35: match the old storyboard recognizer (cancelsTouchesInView=NO,
+    // delaysTouchesEnded=NO). With the default cancelsTouchesInView=YES, a
+    // recognized pan claims every later touch, so no taps land while swirling —
+    // these flags keep touchesBegan: firing, so a held swirl drone can have
+    // tapped notes played over the top.
+    pan.cancelsTouchesInView = NO;
+    pan.delaysTouchesEnded = NO;
     [self.view addGestureRecognizer:pan];
 
     [self buildControlBar];

--- a/PhaseRingsTests/SharedSurfaceTests.m
+++ b/PhaseRingsTests/SharedSurfaceTests.m
@@ -281,6 +281,19 @@
     XCTAssertNotEqual(center, edge);   // inner vs outer ring → different pitch
 }
 
+// Issue #35: the swirl pan recognizer must not swallow touches, or no taps land
+// while a swirl is in progress (drone + tapped melody). Matches the old
+// storyboard recognizer: cancelsTouchesInView=NO, delaysTouchesEnded=NO.
+- (void)testPanRecognizerDoesNotSwallowTouches {
+    UIPanGestureRecognizer *pan = nil;
+    for (UIGestureRecognizer *gr in _vc.view.gestureRecognizers) {
+        if ([gr isKindOfClass:[UIPanGestureRecognizer class]]) pan = (UIPanGestureRecognizer *)gr;
+    }
+    XCTAssertNotNil(pan, @"surface must have its swirl pan recognizer");
+    XCTAssertFalse(pan.cancelsTouchesInView, @"a recognized swirl must keep delivering taps to touchesBegan:");
+    XCTAssertFalse(pan.delaysTouchesEnded);
+}
+
 @end
 
 #pragma mark - 2. OSC message wire format


### PR DESCRIPTION
Closes #35.

The shared surface recreates the swirl `UIPanGestureRecognizer` programmatically with UIKit defaults, where `cancelsTouchesInView = YES`: once a swirl is recognized, the recognizer claims every subsequent touch, so `touchesBegan:` never fires and no tapped notes can be played over a held drone.

The pre-XcodeGen storyboard recognizer was explicitly configured with `cancelsTouchesInView="NO"` and `delaysTouchesEnded="NO"` — which is why the old app supported swirl + tap polyphony. This restores those flags, with a regression test (`testPanRecognizerDoesNotSwallowTouches`) pinning them.

Verified on device: drone + tapped melody works again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)